### PR TITLE
Removed calls to execSync('shx rm...') in favor of shelljs.rm()

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,7 +6,7 @@ var niv = require('./index.js');
 
 var _require = require('./util.js');
 
-var displayHelp = _require.displayHelp;
+var getUsage = _require.getUsage;
 
 
 var options = {
@@ -24,7 +24,13 @@ var options = {
 
 var args = minimist(process.argv.slice(2), options);
 
-if (args.help) displayHelp(0);
-if (!args._.length) displayHelp(1);
+if (args.help) {
+  process.stdout.write(getUsage());
+  process.exit(0);
+}
+if (!args._.length) {
+  process.stderr.write(getUsage());
+  process.exit(1);
+}
 
 niv.install(args._[0], args);

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var execSync = require('child_process').execSync;
+var childProcess = require('child_process');
 var fs = require('fs');
 var path = require('path');
+var shelljs = require('shelljs');
 
 var _require = require('./util.js');
 
@@ -11,8 +12,7 @@ var error = _require.error;
 var sanitize = _require.sanitize;
 
 
-var SHX = 'node node_modules/.bin/shx';
-var TEMP = 'node_modules/.npm-install-version-temp';
+var TEMP = path.join('node_modules', '.npm-install-version-temp');
 
 function install(npmPackage) {
   var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
@@ -31,20 +31,20 @@ function install(npmPackage) {
   var errored = false;
   try {
     // make temp install dir
-    execSync(SHX + ' rm -rf ' + TEMP + '/');
-    execSync(SHX + ' mkdir -p ' + TEMP + '/node_modules/');
+    shelljs.rm('-rf', TEMP);
+    shelljs.mkdir('-p', path.join(TEMP, 'node_modules'));
 
     // install package to temp dir
     var installOptions = {
       cwd: TEMP,
       stdio: [null, null, null]
     };
-    execSync('npm install ' + npmPackage, installOptions);
+    childProcess.spawnSync('npm', ['install', npmPackage], installOptions);
 
     // copy to node_modules/
-    execSync(SHX + ' rm -rf ' + destinationPath);
-    var name = fs.readdirSync(TEMP + '/node_modules/')[0];
-    execSync(SHX + ' mv ' + TEMP + '/node_modules/' + name + ' ' + destinationPath);
+    shelljs.rm('-rf', destinationPath);
+    var name = fs.readdirSync(path.join(TEMP, 'node_modules'))[0];
+    shelljs.mv(path.join(TEMP, 'node_modules', name), destinationPath);
 
     console.log('Installed ' + npmPackage + ' to ' + destinationPath);
   } catch (err) {
@@ -53,7 +53,7 @@ function install(npmPackage) {
     console.log(err.toString());
   } finally {
     // clean up temp install dir
-    execSync(SHX + ' rm -rf ' + TEMP);
+    shelljs.rm('-rf', TEMP);
 
     if (errored) process.exit(1);
   }

--- a/lib/test/cli.js
+++ b/lib/test/cli.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var execSync = require('child_process').execSync;
+var spawnSync = require('child_process').spawnSync;
 var fs = require('fs');
 var path = require('path');
 var test = require('tape');
@@ -11,8 +11,12 @@ var clean = _require.clean;
 
 
 var CLI_PATH = path.join(__dirname, '..', 'cli.js');
-function run(command) {
-  execSync(CLI_PATH + ' ' + command, { stdio: [0, 1, 2] });
+function run() {
+  for (var _len = arguments.length, commands = Array(_len), _key = 0; _key < _len; _key++) {
+    commands[_key] = arguments[_key];
+  }
+
+  spawnSync(CLI_PATH, commands, { stdio: [0, 1, 2] });
 }
 
 test('cli install normal', function (t) {
@@ -33,7 +37,7 @@ test('cli install remote', function (t) {
 
 test('cli install w/ destination', function (t) {
   clean();
-  run('csjs@1.0.0 --destination=csjs@yolo');
+  run('csjs@1.0.0', '--destination=csjs@yolo');
   var packageJson = fs.readFileSync('node_modules/csjs@yolo/package.json');
   t.equal(JSON.parse(packageJson).version, '1.0.0');
   t.end();
@@ -41,11 +45,11 @@ test('cli install w/ destination', function (t) {
 
 test('cli install w/o overwrite', function (t) {
   clean();
-  run('csjs@1.0.0 --destination=csjs@yolo');
+  run('csjs@1.0.0', '--destination=csjs@yolo');
   var packageJson1 = fs.readFileSync('node_modules/csjs@yolo/package.json');
   t.equal(JSON.parse(packageJson1).version, '1.0.0');
 
-  run('csjs@1.0.1 --destination=csjs@yolo');
+  run('csjs@1.0.1', '--destination=csjs@yolo');
   var packageJson2 = fs.readFileSync('node_modules/csjs@yolo/package.json');
   t.equal(JSON.parse(packageJson2).version, '1.0.0');
 
@@ -54,11 +58,11 @@ test('cli install w/o overwrite', function (t) {
 
 test('cli install w/ overwrite', function (t) {
   clean();
-  run('csjs@1.0.0 --destination=csjs@yolo');
+  run('csjs@1.0.0', '--destination=csjs@yolo');
   var packageJson1 = fs.readFileSync('node_modules/csjs@yolo/package.json');
   t.equal(JSON.parse(packageJson1).version, '1.0.0');
 
-  run('csjs@1.0.1 --destination=csjs@yolo --overwrite');
+  run('csjs@1.0.1', '--destination=csjs@yolo', '--overwrite');
   var packageJson2 = fs.readFileSync('node_modules/csjs@yolo/package.json');
   t.equal(JSON.parse(packageJson2).version, '1.0.1');
 
@@ -67,20 +71,20 @@ test('cli install w/ overwrite', function (t) {
 
 test('cli help', function (t) {
   clean();
-  var out = execSync(CLI_PATH + ' --help').toString();
-  t.equal(out.indexOf('usage: niv <package> [options...]'), 0);
-  t.equal(out.length > 100, true);
+  var out = spawnSync(CLI_PATH, ['--help']);
+  var stdout = out.stdout.toString();
+  t.equal(out.status, 0);
+  t.equal(stdout.indexOf('usage: niv <package> [options...]'), 0);
+  t.equal(stdout.length > 100, true);
   t.end();
 });
 
 test('cli no package', function (t) {
   clean();
-  t.plan(2);
-  try {
-    execSync('' + CLI_PATH);
-  } catch (e) {
-    var out = e.stdout.toString();
-    t.equal(out.indexOf('usage: niv <package> [options...]'), 0);
-    t.equal(out.length > 100, true);
-  }
+  var out = spawnSync(CLI_PATH);
+  var stderr = out.stderr.toString();
+  t.equal(out.status, 1);
+  t.equal(stderr.indexOf('usage: niv <package> [options...]'), 0);
+  t.equal(stderr.length > 100, true);
+  t.end();
 });

--- a/lib/test/test-util.js
+++ b/lib/test/test-util.js
@@ -1,9 +1,9 @@
 'use strict';
 
-var execSync = require('child_process').execSync;
+var shelljs = require('shelljs');
 
 function clean() {
-  execSync('./node_modules/.bin/shx rm -rf node_modules/csjs* node_modules/scott113341*');
+  shelljs.rm('-rf', 'node_modules/csjs*', 'node_modules/scott113341*');
 }
 
 module.exports = {

--- a/lib/util.js
+++ b/lib/util.js
@@ -13,18 +13,15 @@ function alreadyInstalled(destination) {
   }
 }
 
-function displayHelp() {
-  var exitCode = arguments.length <= 0 || arguments[0] === undefined ? null : arguments[0];
-
-  var readme = path.join(__dirname, '..', 'README.md');
-  var readmeText = String(fs.readFileSync(readme));
-  var readmeUsageText = /```usage\n([\s\S]*?)```/.exec(readmeText)[1];
-  process.stdout.write(readmeUsageText);
-  if (exitCode !== null) process.exit(exitCode);
-}
-
 function error() {
   throw Error('You must specify an install target like this: csjs@1.0.0');
+}
+
+function getUsage() {
+  var readme = path.join(__dirname, '..', 'README.md');
+  var readmeText = String(fs.readFileSync(readme));
+  return (/```usage\n([\s\S]*?)```/.exec(readmeText)[1]
+  );
 }
 
 function sanitize(npmPackage) {
@@ -33,7 +30,7 @@ function sanitize(npmPackage) {
 
 module.exports = {
   alreadyInstalled: alreadyInstalled,
-  displayHelp: displayHelp,
   error: error,
+  getUsage: getUsage,
   sanitize: sanitize
 };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "minimist": "1.2.0",
     "sanitize-filename": "1.6.0",
+    "shelljs": "0.7.0",
     "shx": "0.1.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
   "dependencies": {
     "minimist": "1.2.0",
     "sanitize-filename": "1.6.0",
-    "shelljs": "0.7.0",
-    "shx": "0.1.2"
+    "shelljs": "0.7.0"
   },
   "devDependencies": {
     "babel": "6.5.2",
@@ -41,6 +40,7 @@
     "babel-preset-es2015": "6.9.0",
     "babel-preset-stage-0": "6.5.0",
     "npm-publish-safe-latest": "1.1.4",
+    "shx": "0.1.2",
     "tape": "4.6.0"
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -2,7 +2,7 @@
 
 const minimist = require('minimist');
 const niv = require('./index.js');
-const { displayHelp } = require('./util.js');
+const { getUsage } = require('./util.js');
 
 
 const options = {
@@ -20,7 +20,13 @@ const options = {
 
 const args = minimist(process.argv.slice(2), options);
 
-if (args.help) displayHelp(0);
-if (!args._.length) displayHelp(1);
+if (args.help) {
+  process.stdout.write(getUsage());
+  process.exit(0);
+}
+if (!args._.length) {
+  process.stderr.write(getUsage());
+  process.exit(1);
+}
 
 niv.install(args._[0], args);

--- a/src/install.js
+++ b/src/install.js
@@ -1,11 +1,12 @@
-const execSync = require('child_process').execSync;
+const childProcess = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const shelljs = require('shelljs');
 
 const { alreadyInstalled, error, sanitize } = require('./util.js');
 
-const SHX = 'node node_modules/.bin/shx';
-const TEMP = 'node_modules/.npm-install-version-temp';
+
+const TEMP = path.join('node_modules', '.npm-install-version-temp');
 
 
 function install(npmPackage, options={}) {
@@ -23,20 +24,20 @@ function install(npmPackage, options={}) {
   var errored = false;
   try {
     // make temp install dir
-    execSync(`${SHX} rm -rf ${TEMP}/`);
-    execSync(`${SHX} mkdir -p ${TEMP}/node_modules/`);
+    shelljs.rm('-rf', TEMP);
+    shelljs.mkdir('-p', path.join(TEMP, 'node_modules'));
 
     // install package to temp dir
     const installOptions = {
       cwd: TEMP,
       stdio: [null, null, null],
     };
-    execSync(`npm install ${npmPackage}`, installOptions);
+    childProcess.spawnSync('npm', ['install', npmPackage], installOptions);
 
     // copy to node_modules/
-    execSync(`${SHX} rm -rf ${destinationPath}`);
-    const name = fs.readdirSync(`${TEMP}/node_modules/`)[0];
-    execSync(`${SHX} mv ${TEMP}/node_modules/${name} ${destinationPath}`);
+    shelljs.rm('-rf', destinationPath);
+    const name = fs.readdirSync(path.join(TEMP, 'node_modules'))[0];
+    shelljs.mv(path.join(TEMP, 'node_modules', name), destinationPath);
 
     console.log(`Installed ${npmPackage} to ${destinationPath}`);
   }
@@ -47,7 +48,7 @@ function install(npmPackage, options={}) {
   }
   finally {
     // clean up temp install dir
-    execSync(`${SHX} rm -rf ${TEMP}`);
+    shelljs.rm('-rf', TEMP);
 
     if (errored) process.exit(1);
   }

--- a/src/test/test-util.js
+++ b/src/test/test-util.js
@@ -1,11 +1,11 @@
-const execSync = require('child_process').execSync;
+const shelljs = require('shelljs');
 
 
 function clean() {
-  execSync(`./node_modules/.bin/shx rm -rf node_modules/csjs* node_modules/scott113341*`);
+  shelljs.rm('-rf', 'node_modules/csjs*', 'node_modules/scott113341*');
 }
 
 
 module.exports = {
-  clean
+  clean,
 };

--- a/src/util.js
+++ b/src/util.js
@@ -14,17 +14,15 @@ function alreadyInstalled(destination) {
 }
 
 
-function displayHelp(exitCode=null) {
-  var readme = path.join(__dirname, '..', 'README.md');
-  var readmeText = String(fs.readFileSync(readme));
-  var readmeUsageText = /```usage\n([\s\S]*?)```/.exec(readmeText)[1];
-  process.stdout.write(readmeUsageText);
-  if (exitCode !== null) process.exit(exitCode);
+function error() {
+  throw Error('You must specify an install target like this: csjs@1.0.0');
 }
 
 
-function error() {
-  throw Error('You must specify an install target like this: csjs@1.0.0');
+function getUsage() {
+  var readme = path.join(__dirname, '..', 'README.md');
+  var readmeText = String(fs.readFileSync(readme));
+  return /```usage\n([\s\S]*?)```/.exec(readmeText)[1];
 }
 
 
@@ -35,7 +33,7 @@ function sanitize(npmPackage) {
 
 module.exports = {
   alreadyInstalled,
-  displayHelp,
   error,
+  getUsage,
   sanitize,
 };


### PR DESCRIPTION
Addresses #5 