### PR TITLE
Fixed bug when target has .bin and/or dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,6 @@ optional:
     overwrite if there is already a package at [destination]
     default: false
 
-  --cmd, -c
-    the custom command line
-    default: npm
-
   --help, -h
     display this message
 ```

--- a/lib/install.js
+++ b/lib/install.js
@@ -1,54 +1,60 @@
 'use strict';
 
 var childProcess = require('child_process');
-var fs = require('fs');
+var fs = require('fs-extra');
 var path = require('path');
 var shelljs = require('shelljs');
 
-var _require = require('./util.js');
+var util = require('./util.js');
 
-var alreadyInstalled = _require.alreadyInstalled;
-var error = _require.error;
-var sanitize = _require.sanitize;
-
-
-var TEMP = path.join('node_modules', '.npm-install-version-temp');
+var TEMP = path.join(process.cwd(), 'node_modules', '.npm-install-version-temp');
 
 function install(npmPackage) {
   var options = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
   var _options$destination = options.destination;
-  var destination = _options$destination === undefined ? sanitize(npmPackage) : _options$destination;
+  var destination = _options$destination === undefined ? util.sanitize(npmPackage) : _options$destination;
   var _options$overwrite = options.overwrite;
   var overwrite = _options$overwrite === undefined ? false : _options$overwrite;
-  var _options$cmd = options.cmd;
-  var cmd = _options$cmd === undefined ? 'npm' : _options$cmd;
 
 
-  if (!npmPackage) error();
+  if (!npmPackage) util.error();
   var destinationPath = path.join('node_modules', destination);
-  if (!overwrite && alreadyInstalled(destinationPath)) {
-    return console.log('Directory ' + destinationPath + ' already exists, skipping');
+  if (!overwrite && util.directoryExists(destinationPath)) {
+    return console.log('Module at ' + destinationPath + ' already exists, skipping');
   }
 
   var errored = false;
   try {
-    // make temp install dir
-    shelljs.rm('-rf', TEMP);
-    shelljs.mkdir('-p', path.join(TEMP, 'node_modules'));
+    (function () {
+      // make temp install dir
+      shelljs.rm('-rf', TEMP);
+      shelljs.mkdir('-p', path.join(TEMP, 'node_modules'));
 
-    // install package to temp dir
-    var installOptions = {
-      cwd: TEMP,
-      stdio: [null, null, null]
-    };
-    childProcess.spawnSync(cmd, ['install', npmPackage], installOptions);
+      // install package to temp dir
+      var installOptions = {
+        cwd: TEMP,
+        stdio: [null, null, null]
+      };
+      childProcess.spawnSync('npm', ['install', npmPackage], installOptions);
 
-    // copy to node_modules/
-    shelljs.rm('-rf', destinationPath);
-    var name = fs.readdirSync(path.join(TEMP, 'node_modules'))[0];
-    shelljs.mv(path.join(TEMP, 'node_modules', name), destinationPath);
+      // get real package name
+      var packageName = util.getPackageName(npmPackage);
 
-    console.log('Installed ' + npmPackage + ' to ' + destinationPath);
+      // copy deps
+      shelljs.mkdir(path.join(TEMP, 'node_modules', packageName, 'node_modules'));
+      shelljs.ls(path.join(TEMP, 'node_modules')).forEach(function (dep) {
+        if (dep === packageName) return;
+        var from = path.join(TEMP, 'node_modules', dep).toString();
+        var to = path.join(TEMP, 'node_modules', packageName, 'node_modules', dep).toString();
+        shelljs.mv(from, to);
+      });
+
+      // copy to node_modules/
+      shelljs.rm('-rf', destinationPath);
+      shelljs.mv(path.join(TEMP, 'node_modules', packageName), destinationPath);
+
+      console.log('Installed ' + npmPackage + ' to ' + destinationPath);
+    })();
   } catch (err) {
     errored = true;
     console.log('Error installing ' + npmPackage);

--- a/lib/test/cli.js
+++ b/lib/test/cli.js
@@ -35,6 +35,14 @@ test('cli install remote', function (t) {
   t.end();
 });
 
+test('cli install w/ dependencies', function (t) {
+  clean();
+  run('push-dir@0.2.2');
+  var packageJson = fs.readFileSync('node_modules/push-dir@0.2.2/package.json');
+  t.equal(JSON.parse(packageJson).version, '0.2.2');
+  t.end();
+});
+
 test('cli install w/ destination', function (t) {
   clean();
   run('csjs@1.0.0', '--destination=csjs@yolo');

--- a/lib/test/install.js
+++ b/lib/test/install.js
@@ -2,7 +2,6 @@
 
 var fs = require('fs');
 var test = require('tape');
-var shelljs = require('shelljs');
 
 var niv = require('../index.js');
 
@@ -22,21 +21,19 @@ test('niv.install normal', function (t) {
   t.end();
 });
 
-test('niv.install with custom cmd', function (t) {
-  clean();
-  niv.install('csjs@1.0.0', {
-    cmd: shelljs.which('npm')
-  });
-  var packageJson = fs.readFileSync('node_modules/csjs@1.0.0/package.json');
-  t.equal(JSON.parse(packageJson).version, '1.0.0');
-  t.end();
-});
-
 test('niv.install remote', function (t) {
   clean();
   niv.install('scott113341/csjs#extract-extends-performance');
   var packageJson = fs.readFileSync('node_modules/scott113341-csjs#extract-extends-performance/package.json');
   t.equal(JSON.parse(packageJson).version, '1.0.4');
+  t.end();
+});
+
+test('niv.install w/ dependencies', function (t) {
+  clean();
+  niv.install('push-dir@0.2.2');
+  var packageJson = fs.readFileSync('node_modules/push-dir@0.2.2/package.json');
+  t.equal(JSON.parse(packageJson).version, '0.2.2');
   t.end();
 });
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,10 +1,12 @@
 'use strict';
 
+var deasync = require('deasync');
 var fs = require('fs');
+var npm = require('npm');
 var path = require('path');
 var sanitizeFilename = require('sanitize-filename');
 
-function alreadyInstalled(destination) {
+function directoryExists(destination) {
   try {
     fs.lstatSync(destination);
     return true;
@@ -15,6 +17,14 @@ function alreadyInstalled(destination) {
 
 function error() {
   throw Error('You must specify an install target like this: csjs@1.0.0');
+}
+
+function getPackageName(packageName) {
+  var load = deasync(npm.load);
+  load({ loaded: false });
+
+  var fetchPackageMetadata = deasync(require('npm/lib/fetch-package-metadata.js'));
+  return fetchPackageMetadata(packageName, process.cwd()).name;
 }
 
 function getUsage() {
@@ -29,8 +39,9 @@ function sanitize(npmPackage) {
 }
 
 module.exports = {
-  alreadyInstalled: alreadyInstalled,
+  directoryExists: directoryExists,
   error: error,
+  getPackageName: getPackageName,
   getUsage: getUsage,
   sanitize: sanitize
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "test": "npm run build && node lib/test/index.js"
   },
   "dependencies": {
+    "fs-extra": "^0.30.0",
     "minimist": "^1.2.0",
+    "npm": "^3.10.5",
     "sanitize-filename": "^1.6.0",
     "shelljs": "^0.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test": "npm run build && node lib/test/index.js"
   },
   "dependencies": {
+    "deasync": "^0.1.7",
     "fs-extra": "^0.30.0",
     "minimist": "^1.2.0",
     "npm": "^3.10.5",

--- a/src/install.js
+++ b/src/install.js
@@ -18,7 +18,7 @@ function install(npmPackage, options={}) {
   if (!npmPackage) util.error();
   const destinationPath = path.join('node_modules', destination);
   if (!overwrite && util.directoryExists(destinationPath)) {
-    return console.log(`Module at ${destinationPath} already exists, skipping`);
+    return console.log(`Directory at ${destinationPath} already exists, skipping`);
   }
 
   var errored = false;

--- a/src/install.js
+++ b/src/install.js
@@ -16,7 +16,7 @@ function install(npmPackage, options={}) {
   } = options;
 
   if (!npmPackage) util.error();
-  const destinationPath = path.join('node_modules', destination);
+  const destinationPath = path.join(process.cwd(), 'node_modules', destination);
   if (!overwrite && util.directoryExists(destinationPath)) {
     return console.log(`Directory at ${destinationPath} already exists, skipping`);
   }

--- a/src/install.js
+++ b/src/install.js
@@ -1,25 +1,24 @@
 const childProcess = require('child_process');
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const shelljs = require('shelljs');
 
-const { alreadyInstalled, error, sanitize } = require('./util.js');
+const util = require('./util.js');
 
 
-const TEMP = path.join('node_modules', '.npm-install-version-temp');
+const TEMP = path.join(process.cwd(), 'node_modules', '.npm-install-version-temp');
 
 
 function install(npmPackage, options={}) {
   const {
-    destination = sanitize(npmPackage),
+    destination = util.sanitize(npmPackage),
     overwrite = false,
-    cmd = 'npm',
   } = options;
 
-  if (!npmPackage) error();
+  if (!npmPackage) util.error();
   const destinationPath = path.join('node_modules', destination);
-  if (!overwrite && alreadyInstalled(destinationPath)) {
-    return console.log(`Directory ${destinationPath} already exists, skipping`);
+  if (!overwrite && util.directoryExists(destinationPath)) {
+    return console.log(`Module at ${destinationPath} already exists, skipping`);
   }
 
   var errored = false;
@@ -33,12 +32,24 @@ function install(npmPackage, options={}) {
       cwd: TEMP,
       stdio: [null, null, null],
     };
-    childProcess.spawnSync(cmd, ['install', npmPackage], installOptions);
+    childProcess.spawnSync('npm', ['install', npmPackage], installOptions);
+
+    // get real package name
+    const packageName = util.getPackageName(npmPackage);
+
+    // copy deps
+    shelljs.mkdir(path.join(TEMP, 'node_modules', packageName, 'node_modules'));
+    shelljs.ls(path.join(TEMP, 'node_modules'))
+      .forEach(dep => {
+        if (dep === packageName) return;
+        const from = path.join(TEMP, 'node_modules', dep).toString();
+        const to = path.join(TEMP, 'node_modules', packageName, 'node_modules', dep).toString();
+        shelljs.mv(from, to);
+      });
 
     // copy to node_modules/
     shelljs.rm('-rf', destinationPath);
-    const name = fs.readdirSync(path.join(TEMP, 'node_modules'))[0];
-    shelljs.mv(path.join(TEMP, 'node_modules', name), destinationPath);
+    shelljs.mv(path.join(TEMP, 'node_modules', packageName), destinationPath);
 
     console.log(`Installed ${npmPackage} to ${destinationPath}`);
   }

--- a/src/install.js
+++ b/src/install.js
@@ -37,7 +37,7 @@ function install(npmPackage, options={}) {
     // get real package name
     const packageName = util.getPackageName(npmPackage);
 
-    // copy deps
+    // move deps inside package
     shelljs.mkdir(path.join(TEMP, 'node_modules', packageName, 'node_modules'));
     shelljs.ls(path.join(TEMP, 'node_modules'))
       .forEach(dep => {

--- a/src/test/cli.js
+++ b/src/test/cli.js
@@ -30,6 +30,15 @@ test('cli install remote', t => {
 });
 
 
+test('cli install w/ dependencies', t => {
+  clean();
+  run('push-dir@0.2.2');
+  const packageJson = fs.readFileSync('node_modules/push-dir@0.2.2/package.json');
+  t.equal(JSON.parse(packageJson).version, '0.2.2');
+  t.end();
+});
+
+
 test('cli install w/ destination', t => {
   clean();
   run('csjs@1.0.0', '--destination=csjs@yolo');

--- a/src/test/install.js
+++ b/src/test/install.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const test = require('tape');
-const shelljs = require('shelljs');
 
 const niv = require('../index.js');
 const { clean } = require('./test-util.js');
@@ -22,22 +21,20 @@ test('niv.install normal', t => {
 });
 
 
-test('niv.install with custom cmd', t => {
-  clean();
-  niv.install('csjs@1.0.0', {
-    cmd: shelljs.which('npm')
-  });
-  const packageJson = fs.readFileSync('node_modules/csjs@1.0.0/package.json');
-  t.equal(JSON.parse(packageJson).version, '1.0.0');
-  t.end();
-});
-
-
 test('niv.install remote', t => {
   clean();
   niv.install('scott113341/csjs#extract-extends-performance');
   const packageJson = fs.readFileSync('node_modules/scott113341-csjs#extract-extends-performance/package.json');
   t.equal(JSON.parse(packageJson).version, '1.0.4');
+  t.end();
+});
+
+
+test('niv.install w/ dependencies', t => {
+  clean();
+  niv.install('push-dir@0.2.2');
+  const packageJson = fs.readFileSync('node_modules/push-dir@0.2.2/package.json');
+  t.equal(JSON.parse(packageJson).version, '0.2.2');
   t.end();
 });
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,9 +1,11 @@
+const deasync = require('deasync');
 const fs = require('fs');
+const npm = require('npm');
 const path = require('path');
 const sanitizeFilename = require('sanitize-filename');
 
 
-function alreadyInstalled(destination) {
+function directoryExists(destination) {
   try {
     fs.lstatSync(destination);
     return true;
@@ -16,6 +18,15 @@ function alreadyInstalled(destination) {
 
 function error() {
   throw Error('You must specify an install target like this: csjs@1.0.0');
+}
+
+
+function getPackageName(packageName) {
+  const load = deasync(npm.load);
+  load({ loaded: false });
+
+  const fetchPackageMetadata = deasync(require('npm/lib/fetch-package-metadata.js'));
+  return fetchPackageMetadata(packageName, process.cwd()).name;
 }
 
 
@@ -32,8 +43,9 @@ function sanitize(npmPackage) {
 
 
 module.exports = {
-  alreadyInstalled,
+  directoryExists,
   error,
+  getPackageName,
   getUsage,
   sanitize,
 };


### PR DESCRIPTION
#10 

Unfortunately, this uses the `npm` package itself, so this will break #9 for now until I can find a workaround.  Maybe some sort of config option when loading `npm`?